### PR TITLE
test: benchmark

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ linters:
     - structcheck # WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
     - ifshort # WARN [runner] The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner.  
     - deadcode # WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
+    - rowserrcheck # WARN [linters_context] rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649. 
+    - wastedassign # WARN [linters_context] wastedassign is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
     - tagliatelle
     - wsl
     - goerr113

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ e.g.
 ```go
 func updateUser() error {
 	// ...
-	return zerr.WithFields(errors.New("get a user"), &zerr.Str{"id", "foo"})
+	return zerr.WithFields(errors.New("get a user"), zerr.Str("id", "foo"))
 }
 ```
 

--- a/zerr/error_internal_test.go
+++ b/zerr/error_internal_test.go
@@ -25,7 +25,7 @@ func Test_zError_Error(t *testing.T) {
 			err: &zError{
 				err: errors.New("foo"),
 				fields: []Field{
-					&Str{"name", "yoo"},
+					Str("name", "yoo"),
 				},
 			},
 			exp: "foo",
@@ -62,7 +62,7 @@ func Test_zError_Unwrap(t *testing.T) {
 			err: &zError{
 				err: errors.New("foo"),
 				fields: []Field{
-					&Str{"name", "yoo"},
+					Str("name", "yoo"),
 				},
 			},
 			exp: errors.New("foo"),
@@ -101,11 +101,11 @@ func Test_zError_Fields(t *testing.T) {
 			err: &zError{
 				err: errors.New("foo"),
 				fields: []Field{
-					&Str{"name", "yoo"},
+					Str("name", "yoo"),
 				},
 			},
 			exp: []Field{
-				&Str{"name", "yoo"},
+				Str("name", "yoo"),
 			},
 		},
 		{
@@ -114,16 +114,16 @@ func Test_zError_Fields(t *testing.T) {
 				err: &zError{
 					err: errors.New("foo"),
 					fields: []Field{
-						&Str{"age", "10"},
+						Str("age", "10"),
 					},
 				},
 				fields: []Field{
-					&Str{"name", "yoo"},
+					Str("name", "yoo"),
 				},
 			},
 			exp: []Field{
-				&Str{"age", "10"},
-				&Str{"name", "yoo"},
+				Str("age", "10"),
+				Str("name", "yoo"),
 			},
 		},
 	}

--- a/zerr/example_test.go
+++ b/zerr/example_test.go
@@ -19,5 +19,5 @@ func Example() {
 
 func updateUser() error {
 	// WithFields adds fields to error
-	return zerr.WithFields(errors.New("get a user"), &zerr.Str{"id", "foo"}, &zerr.Str{"name", "Foo"})
+	return zerr.WithFields(errors.New("get a user"), zerr.Str("id", "foo"), zerr.Str("name", "Foo"))
 }

--- a/zerr/fields.go
+++ b/zerr/fields.go
@@ -6,11 +6,18 @@ type Field interface {
 	With(ev *zerolog.Event) *zerolog.Event
 }
 
-type Str struct {
+type str struct {
 	Key   string
 	Value string
 }
 
-func (field *Str) With(ev *zerolog.Event) *zerolog.Event {
+func (field str) With(ev *zerolog.Event) *zerolog.Event {
 	return ev.Str(field.Key, field.Value)
+}
+
+func Str(key, value string) Field {
+	return str{
+		Key:   key,
+		Value: value,
+	}
 }

--- a/zerr/fields_test.go
+++ b/zerr/fields_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/suzuki-shunsuke/zerolog-error/zerr"
 )
 
-func TestStr_With(t *testing.T) {
+func Test_str_With(t *testing.T) {
 	t.Parallel()
 	data := []struct {
 		name  string
-		field *zerr.Str
+		field zerr.Field
 		ev    *zerolog.Event
 		exp   *zerolog.Event
 	}{
 		{
 			name:  "normal",
-			field: &zerr.Str{"id", "foo"},
+			field: zerr.Str("id", "foo"),
 			ev:    log.Info(),
 			exp:   log.Info().Str("id", "foo"),
 		},

--- a/zerr/main_internal_test.go
+++ b/zerr/main_internal_test.go
@@ -131,3 +131,81 @@ func Test_toFields(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkWithFields(b *testing.B) {
+	err := errors.New("foo")
+	b.Run("normal", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			arr1 := make([]Field, 10)
+			for i := 0; i < 10; i++ {
+				arr1[i] = &Str{
+					fmt.Sprintf("foo-%d", i),
+					fmt.Sprintf("foo-%d", i),
+				}
+			}
+			WithFields(err, arr1...) //nolint:errcheck
+		}
+	})
+	b.Run("str2", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			arr2 := make([]Field, 10)
+			for i := 0; i < 10; i++ {
+				arr2[i] = String(
+					fmt.Sprintf("foo-%d", i),
+					fmt.Sprintf("foo-%d", i),
+				)
+			}
+			WithFields(err, arr2...) //nolint:errcheck
+		}
+	})
+}
+
+func BenchmarkWithError(b *testing.B) {
+	err := errors.New("foo")
+	b.Run("normal", func(b *testing.B) {
+		ev := log.Info()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			arr1 := make([]Field, 10)
+			for i := 0; i < 10; i++ {
+				arr1[i] = &Str{
+					fmt.Sprintf("foo-%d", i),
+					fmt.Sprintf("foo-%d", i),
+				}
+			}
+			WithError(ev, WithFields(err, arr1...))
+		}
+	})
+	b.Run("str2", func(b *testing.B) {
+		ev := log.Info()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			arr2 := make([]Field, 10)
+			for i := 0; i < 10; i++ {
+				arr2[i] = String(
+					fmt.Sprintf("foo-%d", i),
+					fmt.Sprintf("foo-%d", i),
+				)
+			}
+			WithError(ev, WithFields(err, arr2...))
+		}
+	})
+}
+
+type Str2 struct {
+	Key   string
+	Value string
+}
+
+func (field Str2) With(ev *zerolog.Event) *zerolog.Event {
+	return ev.Str(field.Key, field.Value)
+}
+
+func String(key, value string) Str2 {
+	return Str2{
+		Key:   key,
+		Value: value,
+	}
+}

--- a/zerr/main_internal_test.go
+++ b/zerr/main_internal_test.go
@@ -21,19 +21,19 @@ func TestWithFields(t *testing.T) {
 		{
 			name: "nil",
 			fields: []Field{
-				&Str{"id", "foo"},
+				Str("id", "foo"),
 			},
 		},
 		{
 			name: "normal",
 			err:  errors.New("get a user"),
 			fields: []Field{
-				&Str{"id", "foo"},
+				Str("id", "foo"),
 			},
 			exp: &zError{
 				err: errors.New("get a user"),
 				fields: []Field{
-					&Str{"id", "foo"},
+					Str("id", "foo"),
 				},
 			},
 		},
@@ -76,7 +76,7 @@ func TestWithError(t *testing.T) {
 			err: &zError{
 				err: errors.New("foo"),
 				fields: []Field{
-					&Str{"name", "FOO"},
+					Str("name", "FOO"),
 				},
 			},
 		},
@@ -110,12 +110,12 @@ func Test_toFields(t *testing.T) {
 		{
 			name: "zError",
 			exp: []Field{
-				&Str{"name", "FOO"},
+				Str("name", "FOO"),
 			},
 			err: fmt.Errorf("get a user: %w", &zError{
 				err: errors.New("foo"),
 				fields: []Field{
-					&Str{"name", "FOO"},
+					Str("name", "FOO"),
 				},
 			}),
 		},
@@ -139,25 +139,12 @@ func BenchmarkWithFields(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			arr1 := make([]Field, 10)
 			for i := 0; i < 10; i++ {
-				arr1[i] = &Str{
-					fmt.Sprintf("foo-%d", i),
-					fmt.Sprintf("foo-%d", i),
-				}
-			}
-			WithFields(err, arr1...) //nolint:errcheck
-		}
-	})
-	b.Run("str2", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			arr2 := make([]Field, 10)
-			for i := 0; i < 10; i++ {
-				arr2[i] = String(
+				arr1[i] = Str(
 					fmt.Sprintf("foo-%d", i),
 					fmt.Sprintf("foo-%d", i),
 				)
 			}
-			WithFields(err, arr2...) //nolint:errcheck
+			WithFields(err, arr1...) //nolint:errcheck
 		}
 	})
 }
@@ -170,42 +157,12 @@ func BenchmarkWithError(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			arr1 := make([]Field, 10)
 			for i := 0; i < 10; i++ {
-				arr1[i] = &Str{
-					fmt.Sprintf("foo-%d", i),
-					fmt.Sprintf("foo-%d", i),
-				}
-			}
-			WithError(ev, WithFields(err, arr1...))
-		}
-	})
-	b.Run("str2", func(b *testing.B) {
-		ev := log.Info()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			arr2 := make([]Field, 10)
-			for i := 0; i < 10; i++ {
-				arr2[i] = String(
+				arr1[i] = Str(
 					fmt.Sprintf("foo-%d", i),
 					fmt.Sprintf("foo-%d", i),
 				)
 			}
-			WithError(ev, WithFields(err, arr2...))
+			WithError(ev, WithFields(err, arr1...))
 		}
 	})
-}
-
-type Str2 struct {
-	Key   string
-	Value string
-}
-
-func (field Str2) With(ev *zerolog.Event) *zerolog.Event {
-	return ev.Str(field.Key, field.Value)
-}
-
-func String(key, value string) Str2 {
-	return Str2{
-		Key:   key,
-		Value: value,
-	}
 }


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

API is changed.

AS IS

```go
&zerr.Str{"id", "foo"}
```

TO BE

```go
zerr.Str("id", "foo")
```

## Benchmark

I confirmed the benchmark wasn't changed.

9bde3f936ca14e16c018a6d43989ac5a1fe5f693

```console
$ go test -bench . -benchmem
goos: darwin
goarch: arm64
pkg: github.com/suzuki-shunsuke/zerolog-error/zerr
BenchmarkWithFields/normal-8         	 1010006	      1156 ns/op	     426 B/op	      30 allocs/op
BenchmarkWithFields/str2-8           	  976048	      1175 ns/op	     426 B/op	      30 allocs/op
BenchmarkWithError/normal-8          	  706574	      1676 ns/op	    1681 B/op	      35 allocs/op
BenchmarkWithError/str2-8            	  695062	      1653 ns/op	    1695 B/op	      35 allocs/op
PASS
ok  	github.com/suzuki-shunsuke/zerolog-error/zerr	5.618s
```